### PR TITLE
Barcodes updates

### DIFF
--- a/multiqc_c3g/modules/c3g_alignments/AlignmentDuplicationMetrics.py
+++ b/multiqc_c3g/modules/c3g_alignments/AlignmentDuplicationMetrics.py
@@ -32,6 +32,7 @@ def parse_reports(self):
                 if fn_search:
                     s_name = os.path.basename(fn_search.group(1).strip("[]"))
                     s_name = self.clean_s_name(s_name, f)
+                    s_name = re.sub(r'_L00[1-8]$', '', s_name)
                     parsed_data[s_name] = dict()
 
             if s_name is not None:

--- a/multiqc_c3g/modules/c3g_alignments/AlignmentSummaryMetrics.py
+++ b/multiqc_c3g/modules/c3g_alignments/AlignmentSummaryMetrics.py
@@ -34,6 +34,7 @@ def parse_reports(self):
                 if fn_search:
                     s_name = os.path.basename(fn_search.group(1).strip("[]"))
                     s_name = self.clean_s_name(s_name, f)
+                    s_name = re.sub(r'_L00[1-8]$', '', s_name)
                     parsed_data[s_name] = dict()
 
             if s_name is not None:

--- a/multiqc_c3g/modules/c3g_alignments/InsertSizeMetrics.py
+++ b/multiqc_c3g/modules/c3g_alignments/InsertSizeMetrics.py
@@ -19,6 +19,7 @@ def parse_reports(self):
     for f in self.find_log_files("c3g_alignments/insert_size_metrics", filehandles=True):
         in_hist = False
         s_name = self.clean_s_name(f['fn'], f)
+        s_name = re.sub(r'_L00[1-8]$', '', s_name)
         for l in f["f"]:
             if "InsertSizeMetrics" in l and "## METRICS CLASS" in l:
                 self.add_data_source(f, s_name, section="InsertSizeMetrics")

--- a/multiqc_c3g/modules/c3g_alignments/TargetCoverageMetrics.py
+++ b/multiqc_c3g/modules/c3g_alignments/TargetCoverageMetrics.py
@@ -20,6 +20,7 @@ def parse_reports(self):
     # Go through logs and find Metrics
     for f in self.find_log_files("c3g_alignments/target_coverage_metrics", filehandles=True):
         s_name = self.clean_s_name(f['fn'], f)
+        s_name = re.sub(r'_L00[1-8]$', '', s_name)
         parsed_data = dict()
         keys = None
         keys = f["f"].readline().strip("\n").split("\t")

--- a/multiqc_c3g/modules/c3g_demuxmetrics/bcl2fastq.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/bcl2fastq.py
@@ -178,7 +178,7 @@ def parse_reports(self):
             name="Undetermined barcodes by lane",
             anchor="undetermine_by_lane",
             description="Count of the top twenty most abundant undetermined barcodes by lanes",
-            plot=bargraph.plot(
+            plot=table.plot(
                 get_bar_data_from_undetermined(self.bcl2fastq_bylane),
                 headers,
                 {

--- a/multiqc_c3g/modules/c3g_demuxmetrics/bcl2fastq.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/bcl2fastq.py
@@ -113,20 +113,23 @@ def parse_reports(self):
         )
 
         # Add section with undetermined barcodes
+        headers = OrderedDict()
+        for r in range(1,9):
+            headers["L{}".format(r)] = {
+                "title": "L{}".format(r),
+                "description": "Barcode count for Lane {}".format(r),
+                }
         self.add_section(
             name="Undetermined barcodes by lane",
             anchor="undetermine_by_lane",
             description="Count of the top twenty most abundant undetermined barcodes by lanes",
             plot=bargraph.plot(
                 get_bar_data_from_undetermined(self.bcl2fastq_bylane),
-                None,
+                headers,
                 {
                     "id": "bcl2fastq_undetermined",
                     "title": "bcl2fastq: Undetermined barcodes by lane",
-                    "ylab": "Count",
-                    "tt_percentages": False,
-                    "use_legend": True,
-                    "tt_suffix": "reads",
+                    "col1_header": "Sequence"
                 }
             )
         )
@@ -559,9 +562,10 @@ def get_bar_data_from_undetermined(flowcells):
     bar_data = defaultdict(dict)
     # get undetermined barcodes for each lanes
     for lane_id, lane in flowcells.items():
+        lane_header = lane_id.split(" ")[2]
         try:
             for barcode, count in islice(lane["unknown_barcodes"].items(), 20):
-                bar_data[barcode][lane_id] = count
+                bar_data[barcode][lane_header] = count
         except AttributeError:
             pass
 

--- a/multiqc_c3g/modules/c3g_rnaseqc/c3g_rnaseqc.py
+++ b/multiqc_c3g/modules/c3g_rnaseqc/c3g_rnaseqc.py
@@ -122,6 +122,7 @@ class MultiqcModule(RunProcessingBaseModule):
                     except ValueError:
                         data[h] = s[idx]
                 s_name = self.clean_s_name(s_name, f)
+                s_name = re.sub(r'_L00[1-8]$', '', s_name)
                 if s_name in self.rna_seqc_metrics:
                     log.debug(f"Duplicate sample name found! Overwriting: {s_name}")
                 self.rna_seqc_metrics[s_name] = data

--- a/multiqc_c3g/modules/c3g_verifybamid/c3g_verifybamid.py
+++ b/multiqc_c3g/modules/c3g_verifybamid/c3g_verifybamid.py
@@ -97,6 +97,7 @@ class MultiqcModule(BaseMultiqcModule):
             else:
                 # clean the sample name (first column) and assign to s_name
                 s_name = self.clean_s_name(f['fn'], f)
+                s_name = re.sub(r'_L00[1-8]$', '', s_name)
                 # create a dictionary entry with the first column as a key (sample name) and empty dictionary as a value
                 parsed_data[s_name] = {}
                 # for each item in list of items in the row

--- a/multiqc_c3g/runprocessing_base.py
+++ b/multiqc_c3g/runprocessing_base.py
@@ -37,5 +37,7 @@ class RunProcessingBaseModule(BaseMultiqcModule):
         lane_from_path = self.get_lane(f)
         if lane_from_path:
             return "L{} | {}".format(lane_from_path, s_name)
+        
+        s_name = re.sub(r'_L00[1-8]$', '', s_name)
 
         return s_name


### PR DESCRIPTION
Changes requested by François. Adds a new table to the barcodes section that is similar to the laneSummary.html by bcl2fastq and turns the unknown barcodes plot into a table for easier copying and pasting. 

Also fixes issue with inconsistent sample names introduced by adding lane number to the bam file names. 