### PR TITLE
Progress table and unexpected barcodes

### DIFF
--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -212,10 +212,10 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
     for _, d in expected_barcodes.items():
         for row in records:
             if row['BARCODE_NAMES'] and int(row['PF_READS']) > 5000 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
-                s_name = self.clean_s_name(row['BARCODE_NAMES'], lane=lane)
+                s_name = self.clean_s_name(row['BARCODE'], lane=lane)
                 unexpected_metrics[s_name] = {
                     'read_count': row['PF_READS'],
-                    'sequence': row['BARCODE']
+                    'sequence': row['BARCODE_NAMES']
                 }
 
     return unexpected_metrics

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -128,9 +128,10 @@ def parse_reports(self):
         }
         self.add_section(
             name = "Barcodes - Unexpected",
-            description = "Overview of number of clusters assigned to unexpected barcodes.",
+            description = "Overview of number of clusters assigned to unexpected barcodes. Only showing barcodes with ≥50k reads.",
             plot = table.plot(unexpected_data, headers, {"id": "UnexpectedBarcodes", "title": "Unexpected Barcodes", "no_violin": True})
         )
+        print(unexpected_data)
 
     # Return the number of detected samples to the parent module
     return len(report_found)
@@ -212,11 +213,9 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
     for _, d in expected_barcodes.items():
         for row in records:
             if row['BARCODE_NAMES'] and int(row['PF_READS']) > 50000 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
-                print(row)
                 s_name = self.clean_s_name(row['BARCODE'], lane=lane)
                 unexpected_metrics[s_name] = {
                     'read_count': row['PF_READS'],
                     'barcode_names': row['BARCODE_NAMES']
                 }
-                print(unexpected_metrics[s_name])
     return unexpected_metrics

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -215,7 +215,7 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
                 s_name = self.clean_s_name(row['BARCODE'], lane=lane)
                 unexpected_metrics[s_name] = {
                     'read_count': row['PF_READS'],
-                    'barcodes_names': row['BARCODE_NAMES']
+                    'barcode_names': row['BARCODE_NAMES']
                 }
 
     return unexpected_metrics

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -122,9 +122,9 @@ def parse_reports(self):
             'format': '{:,.0f}',
             'max': float(largest_total)
         }
-        headers['sequence'] = {
-            'title': 'Sequence',
-            'description': 'Unexpected found barcode sequence',
+        headers['bardcode_names'] = {
+            'title': 'Barcode name(s)',
+            'description': 'Name of unexpected found barcode sequence',
         }
         self.add_section(
             name = "Barcodes - Unexpected",
@@ -211,11 +211,11 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
 
     for _, d in expected_barcodes.items():
         for row in records:
-            if row['BARCODE_NAMES'] and int(row['PF_READS']) > 5000 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
+            if row['BARCODE_NAMES'] and int(row['PF_READS']) > 50000 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
                 s_name = self.clean_s_name(row['BARCODE'], lane=lane)
                 unexpected_metrics[s_name] = {
                     'read_count': row['PF_READS'],
-                    'sequence': row['BARCODE_NAMES']
+                    'barcodes_names': row['BARCODE_NAMES']
                 }
 
     return unexpected_metrics

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -122,7 +122,7 @@ def parse_reports(self):
             'format': '{:,.0f}',
             'max': float(largest_total)
         }
-        headers['bardcode_names'] = {
+        headers['barcode_names'] = {
             'title': 'Barcode name(s)',
             'description': 'Name of unexpected found barcode sequence',
         }

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -131,7 +131,6 @@ def parse_reports(self):
             description = "Overview of number of clusters assigned to unexpected barcodes. Only showing top 20 unexpected barcodes per lane.",
             plot = table.plot(unexpected_data, headers, {"id": "UnexpectedBarcodes", "title": "Unexpected Barcodes", "no_violin": True})
         )
-        print(unexpected_data)
 
     # Return the number of detected samples to the parent module
     return len(report_found)
@@ -215,9 +214,9 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
             if row['BARCODE_NAMES'] and int(row['PF_READS']) > 0 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
                 s_name = self.clean_s_name(row['BARCODE'], lane=lane)
                 unexpected_metrics[s_name] = {
-                    'read_count': row['PF_READS'],
+                    'read_count': int(row['PF_READS']),
                     'barcode_names': row['BARCODE_NAMES']
                 }
     # keep only top 20 most common unexpected barcodes per lane
-    unexpected_metrics = OrderedDict(sorted(unexpected_metrics.items(), key=lambda x: x[1]['PF_READS'], reverse=True)[:20])
+    unexpected_metrics = OrderedDict(sorted(unexpected_metrics.items(), key=lambda x: x[1]['read_count'], reverse=True)[:20])
     return unexpected_metrics

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -212,10 +212,11 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
     for _, d in expected_barcodes.items():
         for row in records:
             if row['BARCODE_NAMES'] and int(row['PF_READS']) > 50000 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
+                print(row)
                 s_name = self.clean_s_name(row['BARCODE'], lane=lane)
                 unexpected_metrics[s_name] = {
                     'read_count': row['PF_READS'],
                     'barcode_names': row['BARCODE_NAMES']
                 }
-
+                print(unexpected_metrics[s_name])
     return unexpected_metrics

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -128,7 +128,7 @@ def parse_reports(self):
         }
         self.add_section(
             name = "Barcodes - Unexpected",
-            description = "Overview of number of clusters assigned to unexpected barcodes. Only showing barcodes with ≥50k reads.",
+            description = "Overview of number of clusters assigned to unexpected barcodes. Only showing top 20 unexpected barcodes per lane.",
             plot = table.plot(unexpected_data, headers, {"id": "UnexpectedBarcodes", "title": "Unexpected Barcodes", "no_violin": True})
         )
         print(unexpected_data)
@@ -212,10 +212,12 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
 
     for _, d in expected_barcodes.items():
         for row in records:
-            if row['BARCODE_NAMES'] and int(row['PF_READS']) > 50000 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
+            if row['BARCODE_NAMES'] and int(row['PF_READS']) > 0 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
                 s_name = self.clean_s_name(row['BARCODE'], lane=lane)
                 unexpected_metrics[s_name] = {
                     'read_count': row['PF_READS'],
                     'barcode_names': row['BARCODE_NAMES']
                 }
+    # keep only top 20 most common unexpected barcodes per lane
+    unexpected_metrics = OrderedDict(sorted(unexpected_metrics.items(), key=lambda x: x[1]['PF_READS'], reverse=True)[:20])
     return unexpected_metrics

--- a/multiqc_c3g/modules/c3g_progress/c3g_progress.py
+++ b/multiqc_c3g/modules/c3g_progress/c3g_progress.py
@@ -157,7 +157,7 @@ class Job:
                 # Job is finished, but we don't know the exit status
                 # Note that here, the exit status is missing, so we
                 # can't be confident that the job finished without error.
-                return "Complete"
+                return "Error"
             elif self.queue_status == 'R':
                 return "Running"
             elif self.queue_status == 'Y':

--- a/multiqc_c3g/modules/c3g_progress/c3g_progress.py
+++ b/multiqc_c3g/modules/c3g_progress/c3g_progress.py
@@ -66,7 +66,7 @@ class MultiqcModule(BaseMultiqcModule):
         headers['Running'] = {'description': 'Jobs currently running', 'format': '{:,.0f}'}
         headers['Complete'] = {'description': 'Jobs complete', 'format': '{:,.0f}'}
         headers['Error'] = {'description': 'Jobs with errors', 'format': '{:,.0f}'}
-        headers['Cancelled'] = {'description': 'Jobs manually cancelled', 'format': '{:,.0f}', 'hidden': True }
+        headers['Cancelled'] = {'description': 'Jobs manually cancelled', 'format': '{:,.0f}'}
         headers['Unknown'] = {'description': 'Jobs manually unknown', 'format': '{:,.0f}', 'hidden': True }
 
         self.add_section(

--- a/multiqc_c3g/multiqc_c3g.py
+++ b/multiqc_c3g/multiqc_c3g.py
@@ -161,6 +161,7 @@ def c3g_execution():
 
         # increase threshold to turn tables into violin plots
         config.max_table_rows = 10000
+        config.violin_downsample_after = 10000
 
         # Buttons to show/hide by lane
         # TODO dynamic lane list


### PR DESCRIPTION
In the progress table, the cancelled jobs column is now shown by default, instead of being hidden to make it easier to spot runs with issues. 

The unexpected barcodes table that shows CountIlluminaBarcodes metrics now uses the barcode sequence as the sample ID, instead of using the barcode name, which was not unique and would lead to entries being omitted. Only the top 20 most common unexpected barcodes are now shown for each lane. 