### PR TITLE
Debug runtime

### DIFF
--- a/load_tem_scr.sh
+++ b/load_tem_scr.sh
@@ -9,4 +9,4 @@ git clone git@github.com:c3g/MultiQC_c3g.git -b ${commit} $MUGQIC_INSTALL_HOME_D
 
 module purge
 module load python/3.12.2
-pip install --prefix=$MUGQIC_INSTALL_HOME_DEV/software/MultiQC/MultiQC_C3G-${version}_${commit} -U multiqc==${version} git+file:$MUGQIC_INSTALL_HOME_DEV/software/MultiQC_C3G/MultiQC_C3G-${commit}
+pip install --prefix=$MUGQIC_INSTALL_HOME_DEV/software/MultiQC_C3G/MultiQC_C3G-${version}_${commit} -U multiqc==${version} git+file:$MUGQIC_INSTALL_HOME_DEV/software/MultiQC_C3G/MultiQC_C3G-${commit}

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -211,7 +211,7 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
 
     for _, d in expected_barcodes.items():
         for row in records:
-            if row['BARCODE_NAMES'] and int(row['PF_READS']) > 0 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
+            if row['BARCODE_NAMES'] and int(row['PF_READS']) > 50000 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
                 s_name = self.clean_s_name(row['BARCODE'], lane=lane)
                 unexpected_metrics[s_name] = {
                     'read_count': int(row['PF_READS']),

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -210,7 +210,6 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
     unexpected_metrics = dict()
 
     for _, d in expected_barcodes.items():
-        print(expected_barcodes.items())
         for row in records:
             if row['BARCODE_NAMES'] and int(row['PF_READS']) > 50000 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
                 s_name = self.clean_s_name(row['BARCODE'], lane=lane)

--- a/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
+++ b/multiqc_c3g/modules/c3g_demuxmetrics/CountIlluminaBarcodes.py
@@ -210,6 +210,7 @@ def unexpected_metrics(self, records, expected_barcodes, lane):
     unexpected_metrics = dict()
 
     for _, d in expected_barcodes.items():
+        print(expected_barcodes.items())
         for row in records:
             if row['BARCODE_NAMES'] and int(row['PF_READS']) > 50000 and not len(list(filter(lambda barcode_name: d['barcode'] in barcode_name, row['BARCODE_NAMES'].split(',')))):
                 s_name = self.clean_s_name(row['BARCODE'], lane=lane)


### PR DESCRIPTION
I realized that I had set the number of reads to 0 in line 214 during updates to the unexpected barcodes table. Because the majority of lines have 0 reads, this slowed things down a lot. Since we're only interested in the top 20 most common barcodes, I've upped this threshold to something that will improve run time but still catch any common unexpected barcodes. (The top 20 are usually in the 100 thousands and millions of reads).

I've tested with the latest dovee run and it runs within ~10 minutes. 